### PR TITLE
Update valarie.css

### DIFF
--- a/dev5/static/css/valarie.css
+++ b/dev5/static/css/valarie.css
@@ -15,7 +15,7 @@
 }
 
 #procedureResultAccordion td {
-  min-width: 200px;
+  min-width: 2px;
 }
 
 #procedureResultAccordion {


### PR DESCRIPTION
setting min-width: 2px  allows for internal tables to be smaller.  
((I've made the change to the OKC & MONT .css.   See REPL CONN report))
Setting the value to 200px  makes the tables enormous.